### PR TITLE
fix: update broken links pointing to the engine wiki

### DIFF
--- a/pathStructure.md
+++ b/pathStructure.md
@@ -76,7 +76,7 @@
       },
       {
          "name":"I wish to join the Community Discord Channel",
-         "link":"https://github.com/MovingBlocks/Terasology/wiki#communication"
+         "link":"https://github.com/MovingBlocks/Terasology/wiki#announcement-channels"
       }
    ],
    "gooey-response":{

--- a/pathStructure.md
+++ b/pathStructure.md
@@ -76,7 +76,7 @@
       },
       {
          "name":"I wish to join the Community Discord Channel",
-         "link":"https://github.com/MovingBlocks/Terasology/wiki#announcement-channels"
+         "link":"https://discordapp.com/invite/terasology"
       }
    ],
    "gooey-response":{

--- a/src/data/ContributionResources/Conventions.jsx
+++ b/src/data/ContributionResources/Conventions.jsx
@@ -6,11 +6,11 @@ export default {
     },
     {
       name: 'Do you have conventions for comments, too?',
-      link: 'https://github.com/MovingBlocks/Terasology/wiki/JavaDoc',
+      link: 'https://github.com/MovingBlocks/Terasology/wiki/Code-Conventions#javadoc',
     },
     {
       name: 'How about testing?',
-      link: 'https://github.com/MovingBlocks/Terasology/wiki/Unit-Testing',
+      link: 'https://github.com/MovingBlocks/Terasology/wiki/Code-Conventions#testing',
     },
   ],
   'gooey-response': {

--- a/src/data/ContributionResources/Git.jsx
+++ b/src/data/ContributionResources/Git.jsx
@@ -11,11 +11,6 @@ export default {
         link: 'https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/working-with-forks'
       },
       {
-        name: 'Labelling Issues and Pull Request',
-        link:
-          'https://github.com/MovingBlocks/Terasology/wiki/Labelling-Issues-and-Pull-Request',
-      },
-      {
         name: 'Done. What else should I know about?',
         child: ContributionResources,
       },

--- a/src/data/ContributionResources/Workspace.jsx
+++ b/src/data/ContributionResources/Workspace.jsx
@@ -2,11 +2,11 @@ export default {
     'user-responses': [
       {
         name: 'I`m impatient. Give me the quick start!',
-        link: 'https://github.com/MovingBlocks/Terasology/wiki/Dev-Setup',
+        link: 'https://github.com/MovingBlocks/Terasology/wiki/Contributor-Quick-Start',
       },
       {
-        name: 'I have time. Show me the full setup!',
-        link: 'https://github.com/MovingBlocks/Terasology/wiki/Preparing-an-Engine-Workspace',
+        name: 'I want to learn more about the whole project setup!',
+        link: 'https://github.com/MovingBlocks/Terasology/wiki/Project-Overview',
       },
       {
         name: 'Done. Now I`m ready to code!',

--- a/src/data/Terasology/Art/2D.jsx
+++ b/src/data/Terasology/Art/2D.jsx
@@ -8,10 +8,6 @@ export default {
       name: 'Bring me to the tutorial!',
       link: 'https://github.com/Terasology/TutorialAssetSystem/wiki'
     },
-    {
-      name: 'I want to learn more about Aseprite',
-      link: 'https://github.com/MovingBlocks/Terasology/wiki/Aseprite',
-    },
   ],
   'gooey-response': {
     gooey: 'Terasology 2D Art is all about block textures, icons and so on.',

--- a/src/data/Terasology/Art/3D.jsx
+++ b/src/data/Terasology/Art/3D.jsx
@@ -4,14 +4,6 @@ export default {
       name: 'Creation of animated models with Blender',
       link: 'https://github.com/Terasology/TutorialAssetSystem/wiki/Exporting-a-model-for-the-new-glTF-Pipeline-using-Blender',
     },
-    {
-      name: 'Blender Assets',
-      link: 'https://github.com/MovingBlocks/Terasology/wiki/Using-Blender-Assets-as-Miniion-Models',
-    },
-    {
-      name: 'Collada Models',
-      link: 'https://github.com/MovingBlocks/Terasology/wiki/Collada-Models',
-    },
   ],
   'gooey-response': {
     gooey: 'What in 3D Modeling?',

--- a/src/data/Terasology/Contact.jsx
+++ b/src/data/Terasology/Contact.jsx
@@ -5,10 +5,6 @@ export default {
         link: 'https://discord.gg/terasology',
       },
       {
-        name: 'Okay, cool. IRC anybody?',
-        link: 'https://github.com/MovingBlocks/Terasology/wiki/Using-IRC#using-our-chat-systems-including-irc',
-      },
-      {
         name: "Nice, I'm old school, is there a forum?",
         link: 'https://forum.terasology.org/',
       }

--- a/src/data/Terasology/Development/Engine.jsx
+++ b/src/data/Terasology/Development/Engine.jsx
@@ -10,7 +10,7 @@ export default {
       },
       {
         name: "I'm convinced, where do I find engine todos?",
-        link: 'https://github.com/MovingBlocks/Terasology/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Good+First+Issue%22',
+        link: 'https://github.com/MovingBlocks/Terasology/contribute',
       }
     ],
     'gooey-response': {

--- a/src/data/Terasology/Documentation/index.jsx
+++ b/src/data/Terasology/Documentation/index.jsx
@@ -2,7 +2,7 @@ export default {
   'user-responses': [
     {
       name: 'I want to add JavaDoc. Anything I should know?',
-      link: 'https://github.com/MovingBlocks/Terasology/wiki/JavaDoc',
+      link: 'https://github.com/MovingBlocks/Terasology/wiki/Code-Conventions#javadoc',
     },
     {
       name: 'No English? I want to internationalize Terasology!',


### PR DESCRIPTION
As was reported by @Hume2 on Discord, some links of the Adventure Site pointing to the engine wiki are currently broken. 

This PR audits all links to the engine wiki and either replaces them with new targets or removes the dialog options if they are not longer applicable.